### PR TITLE
Implemented multiple new command parameters for CI/CD functionalities for Azure Webapps 

### DIFF
--- a/continuous_delivery/models/__init__.py
+++ b/continuous_delivery/models/__init__.py
@@ -16,7 +16,7 @@ from .provisioning_configuration_source import ProvisioningConfigurationSource
 from .provisioning_configuration_target import ProvisioningConfigurationTarget
 from .slot_swap_configuration import SlotSwapConfiguration
 from .source_repository import SourceRepository
-
+from .create_options import CreateOptions
 
 __all__ = [
     'AuthorizationInfo',
@@ -30,4 +30,5 @@ __all__ = [
     'ProvisioningConfigurationTarget',
     'SlotSwapConfiguration',
     'SourceRepository',
+    'CreateOptions',
 ]

--- a/continuous_delivery/models/authorization_info_parameters.py
+++ b/continuous_delivery/models/authorization_info_parameters.py
@@ -12,8 +12,12 @@ class AuthorizationInfoParameters(Model):
     _attribute_map = {
         'authorization': {'key': 'Authorization', 'type': 'str'},
         'access_token': {'key': 'AccessToken', 'type': 'str'},
+        'username': {'key': 'username', 'type': 'str'},
+        'password': {'key': 'password', 'type': 'str'}
     }
 
-    def __init__(self, authorization=None, access_token=None):
+    def __init__(self, authorization=None, access_token=None, username=None, password=None):
         self.authorization = authorization
         self.access_token = access_token
+        self.username = username
+        self.password = password

--- a/continuous_delivery/models/create_options.py
+++ b/continuous_delivery/models/create_options.py
@@ -1,0 +1,13 @@
+from msrest.serialization import Model
+
+class CreateOptions(Model):
+    _attribute_map = {
+        'app_service_plan_name': {'key': 'appServicePlanName', 'type': 'str'},
+        'app_service_pricing_tier': {'key': 'appServicePricingTier', 'type': 'str'},
+        'base_app_service_name': {'key': 'baseAppServiceName', 'type': 'str'}
+    }
+
+    def __init__(self, app_service_plan_name=None, app_service_pricing_tier=None, base_app_service_name=None):
+        self.app_service_plan_name = app_service_plan_name
+        self.app_service_pricing_tier = app_service_pricing_tier
+        self.base_app_service_name = base_app_service_name

--- a/continuous_delivery/models/provisioning_configuration_target.py
+++ b/continuous_delivery/models/provisioning_configuration_target.py
@@ -22,11 +22,12 @@ class ProvisioningConfigurationTarget(Model):
         'location': {'key': 'location', 'type': 'str'},
         'authorization_info': {'key': 'authorizationInfo', 'type': 'AuthorizationInfo'},
         'slot_swap_configuration': {'key': 'slotSwapConfiguration', 'type': 'SlotSwapConfiguration'},
+        'create_options': {'key': 'createOptions', 'type': 'CreateOptions'}
     }
 
     def __init__(self, provider=None, target_type=None, environment_type=None, friendly_name=None, subscription_id=None, subscription_name=None, tenant_id=None,
                  resource_identifier=None, resource_group_name=None, location=None, authorization_info=None,
-                 slot_swap_configuration=None):
+                 slot_swap_configuration=None, create_options=None):
         self.provider = provider
         self.target_type = target_type
         self.environment_type = environment_type
@@ -39,3 +40,4 @@ class ProvisioningConfigurationTarget(Model):
         self.location = location
         self.authorization_info = authorization_info
         self.slot_swap_configuration = slot_swap_configuration
+        self.create_options = create_options

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 from setuptools import setup, find_packages
 
 NAME = "vsts-cd-manager"
-VERSION = "0.118.0"
+VERSION = "1.0.0"
 
 # To install the library, run the following
 #

--- a/tests/test_continuous_delivery_manager.py
+++ b/tests/test_continuous_delivery_manager.py
@@ -53,11 +53,11 @@ class TestContinousDeliveryManager(unittest.TestCase):
 
     def test_set_repository_info(self):
         cdman = ContinuousDeliveryManager(None)
-        cdman.set_repository_info('repoUrl1', 'master1', 'token1')
+        cdman.set_repository_info('repoUrl1', 'master1', 'token1', None, None)
         self.assertEqual('master1', cdman._repo_info.branch)
         self.assertEqual('token1', cdman._repo_info.git_token)
         self.assertEqual('repoUrl1', cdman._repo_info.url)
-        cdman.set_repository_info(None, None, None)
+        cdman.set_repository_info(None, None, None, None, None)
         self.assertEqual(None, cdman._repo_info.branch)
         self.assertEqual(None, cdman._repo_info.git_token)
         self.assertEqual(None, cdman._repo_info.url)
@@ -77,10 +77,10 @@ class TestContinousDeliveryManager(unittest.TestCase):
         cdman._get_vsts_info = self._mock_get_vsts_info
         # set required values
         cdman.set_azure_web_info('group1', 'web1', 'fakeCreds', 'sub1', 'subname1', 'tenant1', 'South Central US')
-        cdman.set_repository_info('repoUrl1', 'master1', 'token1')
+        cdman.set_repository_info('repoUrl1', 'master1', 'token1', None, None)
         # call setup
         with self.assertRaises(RuntimeError) as context:
-            cdman.setup_continuous_delivery('staging', 'AspNetWap', "account1", False, 'token2')
+            cdman.setup_continuous_delivery('staging', 'AspNet', "account1", False, 'token2', None, None)
         self.assertTrue('does not exist' in str(context.exception))
 
     @patch("vsts_cd_manager.continuous_delivery_manager.ContinuousDelivery")
@@ -100,13 +100,13 @@ class TestContinousDeliveryManager(unittest.TestCase):
         cdman._get_vsts_info = self._mock_get_vsts_info
         # set required values
         cdman.set_azure_web_info('group1', 'web1', 'fakeCreds', 'sub1', 'subname1', 'tenant1', 'South Central US')
-        cdman.set_repository_info('repoUrl1', 'master1', 'token1')
+        cdman.set_repository_info('repoUrl1', 'master1', 'token1', None, None)
         
-        cd_app_type = 'AspNetWap'
-        app_type_details = create_cd_app_type_details_map(cd_app_type, None, None, None)
+        cd_app_type = 'AspNet'
+        app_type_details = create_cd_app_type_details_map(cd_app_type, None, None, None, None)
 
         # call setup
-        result = cdman.setup_continuous_delivery('staging', app_type_details, "account1", True, 'token2')
+        result = cdman.setup_continuous_delivery('staging', app_type_details, "account1", True, 'token2', None, None)
         self.assertEqual('SUCCESS', result.status)
         self.assertTrue("The Team Services account 'https://account1.visualstudio.com' was created" in result.status_message)
         self.assertEqual('https://portal.azure.com/#resource/subscriptions/sub1/resourceGroups/group1/providers/Microsoft.Web/sites/web1/vstscd', result.azure_continuous_delivery_url)
@@ -125,39 +125,43 @@ class TestContinousDeliveryManager(unittest.TestCase):
         nodejs_task_runner = None
         python_framework = None
         python_version = None
+        app_working_dir = None
         test_case_count = 8
         for i in range(test_case_count):
-            cd_app_type, nodejs_task_runner, python_framework, python_version = self._set_build_configuration_variables(i, cd_app_type, nodejs_task_runner, python_framework, python_version)
-            app_type_details = create_cd_app_type_details_map(cd_app_type, nodejs_task_runner, python_framework, python_version)
+            cd_app_type, nodejs_task_runner, python_framework, python_version, app_working_dir = self._set_build_configuration_variables(i)
+            app_type_details = create_cd_app_type_details_map(cd_app_type, nodejs_task_runner, python_framework, python_version, app_working_dir)
             if(i<3) : 
                 # Verifying build configuration outputs
-                build_configuration = cdman._get_build_configuration(app_type_details, None)                
-                self.assertEqual(build_configuration.type, cd_app_type)
+                build_configuration = cdman._get_build_configuration(app_type_details)
                 self.assertEqual(build_configuration.node_type, nodejs_task_runner)
                 self.assertEqual(build_configuration.python_framework, python_framework)
-                self.assertEqual(build_configuration.python_version, python_version)
+                self.assertEqual(build_configuration.working_directory, app_working_dir)
+                if(python_version is not None) :
+                    self.assertEqual(build_configuration.python_version, python_version.replace(" ", "").replace(".", ""))
+                cd_app_type = 'AspNetWap' if cd_app_type == 'AspNet' else cd_app_type     
+                self.assertEqual(build_configuration.type, cd_app_type)
             else :
                 # Verifying exceptions
                 with self.assertRaises(RuntimeError):
-                    cdman._get_build_configuration(app_type_details, None)
+                    cdman._get_build_configuration(app_type_details)
 
-    def _set_build_configuration_variables(self, i, cd_app_type, nodejs_task_runner, python_framework, python_version):
+    def _set_build_configuration_variables(self, i):
         if(i==0):
-            return 'Python', None, 'Django', 'Python 2.7.12 x64'
+            return 'Python', None, 'Django', 'Python 2.7.12 x64', 'app_working_dir'
         elif(i==1):
-            return 'NodeJS', 'Gulp', None, None
+            return 'NodeJS', 'Gulp', None, None, None
         elif(i==2):
-            return 'AspNetWap', None, None, None
+            return 'AspNet', None, None, None, None
         elif(i==3):
-            return None, None, None, None
+            return None, None, None, None, None
         elif(i==4):
-            return 'UnacceptedAppType', None, None, None
+            return 'UnacceptedAppType', None, None, None, None
         elif(i==5):
-            return 'Python', None, 'UnacceptedFramework', 'Python 2.7.12 x64'
+            return 'Python', None, 'UnacceptedFramework', 'Python 2.7.12 x64', None
         elif(i==6):
-            return 'Python', 'Django', None, 'UnexpectedVersion'
+            return 'Python', 'Django', None, 'UnexpectedVersion', None
         elif(i==7):
-            return 'NodeJS', 'UnexpectedNodeJSTaskRunner', None, None
+            return 'NodeJS', 'UnexpectedNodeJSTaskRunner', None, None, None
     
     def _mock_get_vsts_info(self, vsts_repo_url, cred):
         collection_info = CollectionInfo('111', 'collection111', 'https://collection111.visualstudio.com')
@@ -173,12 +177,13 @@ class TestContinousDeliveryManager(unittest.TestCase):
             CiResult(status, status_message))
         return ProvisioningConfiguration('abcd', None, None, ci_config)
 
-def create_cd_app_type_details_map(cd_app_type, nodejs_task_runner, python_framework, python_version):
+def create_cd_app_type_details_map(cd_app_type, nodejs_task_runner, python_framework, python_version, app_working_dir):
     return {
         'cd_app_type' : cd_app_type,
         'nodejs_task_runner' : nodejs_task_runner,
         'python_framework' : python_framework,
-        'python_version' : python_version
+        'python_version' : python_version,
+        'app_working_dir' : app_working_dir
     }
 
 if __name__ == '__main__':

--- a/vsts_cd_manager/continuous_delivery_manager.py
+++ b/vsts_cd_manager/continuous_delivery_manager.py
@@ -152,7 +152,7 @@ class ContinuousDeliveryManager(object):
         else:
             raise RuntimeError('Unknown status returned from provisioning_configuration: ' + response.ci_configuration.result.status)
 
-    def get_provisioning_configuration_target(auth_info, azure_deployment_slot, test, webapp_list):
+    def get_provisioning_configuration_target(self, auth_info, azure_deployment_slot, test, webapp_list):
         azure_deployment_slot_config = None if azure_deployment_slot is None else SlotSwapConfiguration(azure_deployment_slot)
         slotTarget = ProvisioningConfigurationTarget('azure', 'windowsAppService', 'production', 'Production',
                                                  self._azure_info.subscription_id, self._azure_info.subscription_name, 

--- a/vsts_cd_manager/continuous_delivery_manager.py
+++ b/vsts_cd_manager/continuous_delivery_manager.py
@@ -155,7 +155,7 @@ class ContinuousDeliveryManager(object):
             raise RuntimeError('Unknown status returned from provisioning_configuration: ' + response.ci_configuration.result.status)
     
     def _validate_cd_project_url(self, cd_project_url):
-        if not cd_project_url.find('visualstudio.com') or not cd_project_url.find('https://'):
+        if -1 == cd_project_url.find('visualstudio.com') or -1 == cd_project_url.find('https//'):
             raise RuntimeError('Project URL should be in format https://<accountname>.visualstudio.com/<projectname>')
 
     def _get_vsts_account_name(self, cd_project_url):

--- a/vsts_cd_manager/continuous_delivery_manager.py
+++ b/vsts_cd_manager/continuous_delivery_manager.py
@@ -155,7 +155,7 @@ class ContinuousDeliveryManager(object):
             raise RuntimeError('Unknown status returned from provisioning_configuration: ' + response.ci_configuration.result.status)
     
     def _validate_cd_project_url(self, cd_project_url):
-        if -1 == cd_project_url.find('visualstudio.com') or -1 == cd_project_url.find('https//'):
+        if -1 == cd_project_url.find('visualstudio.com') or -1 == cd_project_url.find('https://'):
             raise RuntimeError('Project URL should be in format https://<accountname>.visualstudio.com/<projectname>')
 
     def _get_vsts_account_name(self, cd_project_url):
@@ -171,7 +171,7 @@ class ContinuousDeliveryManager(object):
         target = [slotTarget]
         if test is not None:
             create_options = None
-            if not any(s.name == test for s in webapp_list) :
+            if webapp_list is not None and not any(s.name == test for s in webapp_list) :
                 app_service_plan_name = 'ServicePlan'+ str(uuid.uuid4())[:13]
                 create_options = CreateOptions(app_service_plan_name, 'Standard', self._azure_info.website_name)
             testTarget = ProvisioningConfigurationTarget('azure', 'windowsAppService', 'test', 'Load Test',
@@ -248,10 +248,6 @@ class ContinuousDeliveryManager(object):
                     type = 'Github'
                     identifier = match.group(1).replace(".git", "")
                     auth_info = AuthorizationInfo('PersonalAccessToken', AuthorizationInfoParameters(None, token))
-                elif username is not None and password is not None:                    
-                    type = 'Git'
-                    identifier = uri
-                    auth_info = AuthorizationInfo('UsernamePassword', AuthorizationInfoParameters(None, None, username, password))            
             else:
                 match = re.match(r'[htps]+\:\/\/(.+)\.visualstudio\.com\/(.+)', uri, re.IGNORECASE)
                 if match:

--- a/vsts_cd_manager/continuous_delivery_manager.py
+++ b/vsts_cd_manager/continuous_delivery_manager.py
@@ -85,11 +85,11 @@ class ContinuousDeliveryManager(object):
         # TODO: this would be called by appservice web source-control delete
         return
 
-    def setup_continuous_delivery(self, azure_deployment_slot, app_type_details, cd_project_url, create_account,
+    def setup_continuous_delivery(self, swap_with_slot, app_type_details, cd_project_url, create_account,
                                   vsts_app_auth_token, test, webapp_list):
         """
         Use this method to setup Continuous Delivery of an Azure web site from a source control repository.
-        :param azure_deployment_slot: the slot to use for deployment
+        :param swap_with_slot: the slot to use for deployment
         :param app_type_details: the details of app that will be deployed. i.e. app_type = Python, python_framework = Django etc.
         :param cd_project_url: CD Project url in the format of https://<accountname>.visualstudio.com/<projectname> 
         :param create_account: Boolean value to decide if account need to be created or not
@@ -141,7 +141,7 @@ class ContinuousDeliveryManager(object):
         build_configuration = self._get_build_configuration(app_type_details)
         source = ProvisioningConfigurationSource('codeRepository', source_repository, build_configuration)
         auth_info = AuthorizationInfo('Headers', AuthorizationInfoParameters('Bearer ' + vsts_app_auth_token))
-        target = self.get_provisioning_configuration_target(auth_info, azure_deployment_slot, test, webapp_list)
+        target = self.get_provisioning_configuration_target(auth_info, swap_with_slot, test, webapp_list)
         ci_config = CiConfiguration(CiArtifact(name=cd_project_name))
         config = ProvisioningConfiguration(None, source, target, ci_config)
 
@@ -161,13 +161,13 @@ class ContinuousDeliveryManager(object):
     def _get_vsts_account_name(self, cd_project_url):
         return (cd_project_url.split('.visualstudio.com', 1)[0]).strip('https://')
 
-    def get_provisioning_configuration_target(self, auth_info, azure_deployment_slot, test, webapp_list):
-        azure_deployment_slot_config = None if azure_deployment_slot is None else SlotSwapConfiguration(azure_deployment_slot)
+    def get_provisioning_configuration_target(self, auth_info, swap_with_slot, test, webapp_list):
+        swap_with_slot_config = None if swap_with_slot is None else SlotSwapConfiguration(swap_with_slot)
         slotTarget = ProvisioningConfigurationTarget('azure', 'windowsAppService', 'production', 'Production',
                                                  self._azure_info.subscription_id, self._azure_info.subscription_name, 
                                                  self._azure_info.tenant_id, self._azure_info.website_name, 
                                                  self._azure_info.resource_group_name, self._azure_info.webapp_location, 
-                                                 auth_info, azure_deployment_slot_config)
+                                                 auth_info, swap_with_slot_config)
         target = [slotTarget]
         if test is not None:
             create_options = None

--- a/vsts_cd_manager/continuous_delivery_manager.py
+++ b/vsts_cd_manager/continuous_delivery_manager.py
@@ -64,11 +64,11 @@ class ContinuousDeliveryManager(object):
     def set_repository_info(self, repo_url, branch, git_token, private_repo_username, private_repo_password):
         """
         Call this method before attempting to setup continuous delivery to setup the source control settings
-        :param repo_url:
-        :param branch:
-        :param git_token:
-        :param private_repo_username:
-        :param private_repo_password:
+        :param repo_url: URL of the code repo
+        :param branch: repo branch
+        :param git_token: git token
+        :param private_repo_username: private repo username
+        :param private_repo_password: private repo password
         :return:
         """
         self._repo_info.url = repo_url
@@ -91,9 +91,9 @@ class ContinuousDeliveryManager(object):
         Use this method to setup Continuous Delivery of an Azure web site from a source control repository.
         :param azure_deployment_slot: the slot to use for deployment
         :param app_type_details: the details of app that will be deployed. i.e. app_type = Python, python_framework = Django etc.
-        :param cd_project_url:
-        :param create_account:
-        :param vsts_app_auth_token:
+        :param cd_project_url: CD Project url in the format of https://<accountname>.visualstudio.com/<projectname> 
+        :param create_account: Boolean value to decide if account need to be created or not
+        :param vsts_app_auth_token: Authentication token for vsts app
         :param test: Load test webapp name
         :param webapp_list: Existing webapp list
         :return: a message indicating final status and instructions for the user
@@ -226,11 +226,13 @@ class ContinuousDeliveryManager(object):
     def _get_source_repository(self, uri, token, branch, cred, username, password):
         # Determine the type of repository (TfsGit, github, tfvc, externalGit)
         # Find the identifier and set the properties; default to externalGit
-        type = 'ExternalGit'
+        type = 'Git'
         identifier = uri
         account_name = None
         team_project_name = None
         auth_info = None
+        if username is not None and password is not None: 
+            auth_info = AuthorizationInfo('UsernamePassword', AuthorizationInfoParameters(None, None, username, password))
         match = re.match(r'[htps]+\:\/\/(.+)\.visualstudio\.com.*\/_git\/(.+)', uri, re.IGNORECASE)
         if match:
             type = 'TfsGit'
@@ -242,11 +244,11 @@ class ContinuousDeliveryManager(object):
         else:
             match = re.match(r'[htps]+\:\/\/github\.com\/(.+)', uri, re.IGNORECASE)
             if match:
-                if username is None and password is None:                    
+                if token is not None:                    
                     type = 'Github'
                     identifier = match.group(1).replace(".git", "")
                     auth_info = AuthorizationInfo('PersonalAccessToken', AuthorizationInfoParameters(None, token))
-                else:                    
+                elif username is not None and password is not None:                    
                     type = 'Git'
                     identifier = uri
                     auth_info = AuthorizationInfo('UsernamePassword', AuthorizationInfoParameters(None, None, username, password))            


### PR DESCRIPTION
Implemented following new command parameters for CI/CD functionalities for Azure Webapps:

cd-account-create
app-working-directory
private-repo-username
private-repo-password
cd-project-url
test
swap-slot

Along with these, added support for PHP, Python and NodeJS Webapps.