### PR TITLE
Fixing a bug to fetch correct account name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 from setuptools import setup, find_packages
 
 NAME = "vsts-cd-manager"
-VERSION = "1.0.1"
+VERSION = "1.0.2"
 
 # To install the library, run the following
 #

--- a/vsts_cd_manager/continuous_delivery_manager.py
+++ b/vsts_cd_manager/continuous_delivery_manager.py
@@ -157,7 +157,7 @@ class ContinuousDeliveryManager(object):
             raise RuntimeError('Project URL should be in format https://<accountname>.visualstudio.com/<projectname>')
 
     def _get_vsts_account_name(self, cd_project_url):
-        return (cd_project_url.split('.visualstudio.com', 1)[0]).strip('https://')
+        return (cd_project_url.split('.visualstudio.com', 1)[0]).split('https://', 1)[1]
 
     def get_provisioning_configuration_target(self, auth_info, swap_with_slot, test, webapp_list):
         swap_with_slot_config = None if swap_with_slot is None else SlotSwapConfiguration(swap_with_slot)


### PR DESCRIPTION
Replaced .strip() with .split() to fetch correct account name